### PR TITLE
Add Variant#images method

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -350,6 +350,10 @@ module Spree
       end.flatten.compact
     end
 
+    def images
+      Variant.reflect_on_association(:images) ? association(:images).reader : []
+    end
+
     private
 
     def rebuild_vat_prices?


### PR DESCRIPTION
This wraps the `has_many :images` association on `Spree::Variant`. By
doing this we can safely consider removing images from Solidus core
without breaking the API of `Spree::Variant`.